### PR TITLE
add gh-scoped-creds

### DIFF
--- a/jupyterhub/gfts-hub/values.yaml
+++ b/jupyterhub/gfts-hub/values.yaml
@@ -40,6 +40,8 @@ jupyterhub:
       CULL_TIMEOUT: "1800"
       CULL_KERNEL_TIMEOUT: "1800"
       CULL_INTERVAL: "120"
+      GH_SCOPED_CREDS_CLIENT_ID: Iv1.f4a7db20c671f599
+      GH_SCOPED_CREDS_APP_URL: https://github.com/apps/gfts-jupyterhub
       AWS_ENDPOINT_URL_S3: "https://s3.gra.perf.cloud.ovh.net"
       AWS_DEFAULT_REGION: gra
       # JUPYTER_FS_BUCKETS: destine-gfts-data-lake,gfts-reference-data,gfts-ifremer

--- a/jupyterhub/images/user/requirements.txt
+++ b/jupyterhub/images/user/requirements.txt
@@ -2,6 +2,7 @@
 # if they should be installed with conda,
 # use conda-requirements.txt
 
+gh-scoped-creds
 jupyterhub==4.1.5
 # git+https://github.com/iaocea/pangeo-fish#egg=pangeo-fish
 git+https://github.com/iaocea/xarray-healpy#egg=xarray-healpy


### PR DESCRIPTION
can add push permissions to individual repos via https://github.com/apps/gfts-jupyterhub

Run `gh-scoped-creds` in a shell to enable push permissions for a given jupyterhub session.