### PR TITLE
list deliverables

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -11,3 +11,6 @@ parts:
       - file: s3_CMEMS_2D_kerchunk
       - file: s3_CMEMS_3D_kerchunk
       - file: s3chunked_parquet
+  - caption: Reporting
+    chapters:
+      - file: deliverables

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -1,0 +1,15 @@
+# Project deliverables and reports
+
+All our deliverables and reports are deposited in Zenodo and can be uniquely identified through their Digital Object Identifier (DOI).
+
+For each deliverable and/or report, click on the DOI icon to get the corresponding report:
+
+- Deliverable 5.1 - Project Management Plan for GFTS Use Case Application [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11185947.svg)](https://doi.org/10.5281/zenodo.11185947)
+- Deliverable 5.2 - Use Case Descriptor for GFTS Use Case Application [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186083.svg)](https://doi.org/10.5281/zenodo.11186083)
+- Deliverable 5.3 - GFTS Use case Application [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186122.svg)](https://doi.org/10.5281/zenodo.11186122)
+- Deliverable 5.5 - GFTS Use Case Promotion Package [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186178.svg)](https://doi.org/10.5281/zenodo.11186178)
+- Software Reuse File for the GFTS DestinE Platform Use Case [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186190.svg)](https://doi.org/10.5281/zenodo.11186190)
+- GFTS Software Release Plan [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186226.svg)](https://doi.org/10.5281/zenodo.11186226)
+- GFTS Software Requirement Specifications [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186256.svg)](https://doi.org/10.5281/zenodo.11186256)
+- GFTS Software Verification and Validation Plan [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186287.svg)](https://doi.org/10.5281/zenodo.11186287)
+- GFTS Software Verification and Validation Report [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11186317.svg)](https://doi.org/10.5281/zenodo.11186317)


### PR DESCRIPTION
This is an alternative to https://github.com/destination-earth/DestinE_ESA_GFTS/pull/29 e.g. deliverables and reports are deposited in Zenodo and we add the links in our documentation.