### PR TITLE
keep kbatch jobs for one week after finish

### DIFF
--- a/gfts-track-reconstruction/jupyterhub/gfts-hub/values.yaml
+++ b/gfts-track-reconstruction/jupyterhub/gfts-hub/values.yaml
@@ -365,6 +365,11 @@ kbatch-proxy:
             labels:
               app.kubernetes.io/managed-by: kbatch
           spec:
+            # the time before a job is deleted after finishing
+            # ideally, we use a mutating webhook
+            # to keep failures for longer than success
+            # default: 1 week
+            ttlSecondsAfterFinished: 604800
             template:
               metadata:
                 labels:


### PR DESCRIPTION
ideally, this would only be for failures, which is a [documented application of mutating admission webhooks](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/), but I cannot find any examples to reference.