### PR TITLE
Update some s3 permissions

### DIFF
--- a/gfts-track-reconstruction/jupyterhub/tofu/main.tf
+++ b/gfts-track-reconstruction/jupyterhub/tofu/main.tf
@@ -54,7 +54,7 @@ locals {
     "gfts-reference-data",
     "destine-gfts-data-lake",
   ])
-  
+
   # users must appear in only one of these sets
   # because each user can have exactly one policy
   s3_readonly_users = toset([
@@ -90,6 +90,18 @@ locals {
     "s3:ListMultipartUploadParts", "s3:ListBucketMultipartUploads",
     "s3:AbortMultipartUpload", "s3:GetBucketLocation",
   ]
+  
+  # default-deny policy
+  # disallows bucket creation
+  s3_default_deny = {
+    "Sid" : "default-deny",
+    "Effect" : "Deny",
+    "Action" : [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+    ],
+    "Resource" : ["arn:aws:s3:::*"]
+  }
 }
 
 ####### s3 buckets #######
@@ -167,10 +179,13 @@ resource "ovh_cloud_project_user_s3_policy" "s3_users" {
         "Effect" : "Allow",
         "Action" : local.s3_readonly_action,
         "Resource" : [
+          "arn:aws:s3:::${aws_s3_bucket.gfts-data-lake.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-data-lake.id}/*",
+          "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}/*",
         ]
       },
+      local.s3_default_deny,
     ]
   })
 }
@@ -186,7 +201,9 @@ resource "ovh_cloud_project_user_s3_policy" "s3_ifremer_users" {
         "Effect" : "Allow",
         "Action" : local.s3_readonly_action,
         "Resource" : [
+          "arn:aws:s3:::${aws_s3_bucket.gfts-data-lake.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-data-lake.id}/*",
+          "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}/*",
         ]
       },
@@ -195,9 +212,11 @@ resource "ovh_cloud_project_user_s3_policy" "s3_ifremer_users" {
         "Effect" : "Allow",
         "Action" : local.s3_admin_action,
         "Resource" : [
+          "arn:aws:s3:::${aws_s3_bucket.gfts-ifremer.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-ifremer.id}/*",
         ]
       },
+      local.s3_default_deny,
     ]
   })
 }
@@ -213,7 +232,9 @@ resource "ovh_cloud_project_user_s3_policy" "s3_ifremer_developers" {
         "Effect" : "Allow",
         "Action" : local.s3_readonly_action,
         "Resource" : [
+          "arn:aws:s3:::${aws_s3_bucket.gfts-data-lake.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-data-lake.id}/*",
+          "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}/*",
         ]
       },
@@ -222,10 +243,13 @@ resource "ovh_cloud_project_user_s3_policy" "s3_ifremer_developers" {
         "Effect" : "Allow",
         "Action" : local.s3_admin_action,
         "Resource" : [
+          "arn:aws:s3:::${aws_s3_bucket.gfts-ifremer.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-ifremer.id}/*",
+          "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}",
           "arn:aws:s3:::${aws_s3_bucket.gfts-reference-data.id}/*",
         ]
       },
+      local.s3_default_deny,
     ]
   })
 }

--- a/gfts-track-reconstruction/jupyterhub/tofu/main.tf
+++ b/gfts-track-reconstruction/jupyterhub/tofu/main.tf
@@ -288,6 +288,15 @@ resource "aws_s3_bucket_acl" "gfts-reference-data" {
       }
     }
 
+    # everyone authenticated can read reference data
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+      }
+      permission = "READ"
+    }
+
     dynamic "grant" {
       for_each = local.s3_ifremer_users
       content {

--- a/gfts-track-reconstruction/jupyterhub/tofu/main.tf
+++ b/gfts-track-reconstruction/jupyterhub/tofu/main.tf
@@ -613,6 +613,7 @@ provider "harbor" {
 
 resource "harbor_project" "registry" {
   name = "gfts"
+  public = true
 }
 
 resource "harbor_robot_account" "builder" {


### PR DESCRIPTION
- make user image public (needed for kbatch)
- make reference-data read-only for all users, like data lake
- deny bucket creation permissions to all s3 users (all documentation I can find suggests this is meant to be the default, but doesn't appear to be)
- update some wildcards in user policies because bucket operations are done on `bucket-name` while Object operations are on `bucket-name/*`