### PR TITLE
add pangeo-fish to image, bump dependencies

### DIFF
--- a/gfts-track-reconstruction/jupyterhub/images/user/Dockerfile
+++ b/gfts-track-reconstruction/jupyterhub/images/user/Dockerfile
@@ -1,5 +1,4 @@
-# trigger rebuild: 2024-11-22
-FROM quay.io/pangeo/pangeo-notebook:2024.08.18
+FROM quay.io/pangeo/pangeo-notebook:2025.01.24
 # Install fusermount3 command and open GL library
 USER root
 RUN apt-get update && apt-get install -y fuse3 libgl1 xvfb

--- a/gfts-track-reconstruction/jupyterhub/images/user/conda-requirements.txt
+++ b/gfts-track-reconstruction/jupyterhub/images/user/conda-requirements.txt
@@ -7,8 +7,11 @@ copernicusmarine
 dask-image
 eccodes>=2.35.0
 fastparquet
+h3ronpy
 healpy
+imageio-ffmpeg
 jq
+movingpandas
 papermill
 pixi
 pre-commit

--- a/gfts-track-reconstruction/jupyterhub/images/user/requirements.txt
+++ b/gfts-track-reconstruction/jupyterhub/images/user/requirements.txt
@@ -6,8 +6,7 @@ gh-scoped-creds
 isort
 jupyter-keepalive
 jupyterhub==4.1.6
-kbatch @ git+https://github.com/kbatch-dev/kbatch@1c18c485d5482fa8878dfedf922201b5e8556528#subdirectory=kbatch
-kbatch-papermill @ git+https://github.com/minrk/kbatch-papermill
-# git+https://github.com/iaocea/pangeo-fish#egg=pangeo-fish
-#git+https://github.com/iaocea/xarray-regridding#egg=xarray-regridding
-xarray-healpy @ git+https://github.com/iaocea/xarray-regridding.git@0ffca6058f4008f4f22f076e2d60787fcf32ac82
+kbatch==0.5.0a2
+kbatch-papermill==0.1.0a1
+pangeo-fish==2025.03.1
+xarray-healpy @ git+https://github.com/iaocea/xarray-healpy.git@9d036a1b221f1b052cc4b1d09d45ac0e5166e403

--- a/gfts-track-reconstruction/jupyterhub/images/user/requirements.txt
+++ b/gfts-track-reconstruction/jupyterhub/images/user/requirements.txt
@@ -8,5 +8,5 @@ jupyter-keepalive
 jupyterhub==4.1.6
 kbatch==0.5.0a2
 kbatch-papermill==0.1.0a1
-pangeo-fish==2025.03.1
-xarray-healpy @ git+https://github.com/iaocea/xarray-healpy.git@9d036a1b221f1b052cc4b1d09d45ac0e5166e403
+pangeo-fish==2025.3.1
+xarray-healpy==2025.3.2


### PR DESCRIPTION
- bump base image to quay.io/pangeo/pangeo-notebook:2025.01.24
- add stable pangeo-fish 2025.03.1 to image
- add a couple pangeo-fish dependencies to conda-requirements so they get used instead of wheels
- use tagged kbatch prereleases
- update commit for unreleased xarray-healpy