### PR TITLE
install new xhealpixify package in user image

### DIFF
--- a/gfts-track-reconstruction/jupyterhub/images/user/requirements.txt
+++ b/gfts-track-reconstruction/jupyterhub/images/user/requirements.txt
@@ -9,4 +9,4 @@ jupyterhub==4.1.6
 kbatch==0.5.0a2
 kbatch-papermill==0.1.0a1
 pangeo-fish==2025.3.1
-xarray-healpy==2025.3.2
+xhealpixify==2025.3.3


### PR DESCRIPTION
xarray-healpix has been removed from PyPI, so previous image can no longer build https://github.com/IAOCEA/xhealpixify/pull/34