### PR TITLE
try pinning back boto3 to avoid problems with removed MD5 support

### DIFF
--- a/gfts-track-reconstruction/jupyterhub/images/user/conda-requirements.txt
+++ b/gfts-track-reconstruction/jupyterhub/images/user/conda-requirements.txt
@@ -1,7 +1,10 @@
+# pin back aiobotocore/boto3 due to Content-MD5 header problems on Delete
+aiobotocore==2.16.*
 # packages to be installed with conda
 # requirements.txt format
 # to install with pip, use requirements.txt
 altair
+boto3==1.35.*
 cdshealpix
 copernicusmarine
 dask-image


### PR DESCRIPTION
#149 fixed _some_ operations, but apparently not delete. The only recourse is apparently to hold boto3 back, which won't work forever. Other than that, we just have to hope OVH upgrades their s3 hash implementation to include supported checksums before this is too much of a problem.