### PR TITLE
Fix and improve the Visualization Workflow

### DIFF
--- a/docs/workflow/regroup_results.ipynb
+++ b/docs/workflow/regroup_results.ipynb
@@ -47,6 +47,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
+    "PROFILE = \"gfts\"\n",
     "\n",
     "SOURCE_BUCKET = \"gfts-ifremer\"\n",
     "TARGET_BUCKET = \"destine-gfts-visualisation-data\"\n",
@@ -65,6 +66,7 @@
    "outputs": [],
    "source": [
     "# set the constant values as environment variables\n",
+    "os.environ[\"PROFILE\"] = PROFILE\n",
     "os.environ[\"SOURCE_BUCKET\"] = SOURCE_BUCKET\n",
     "os.environ[\"TARGET_BUCKET\"] = TARGET_BUCKET\n",
     "os.environ[\"TAG_ROOT\"] = TAG_ROOT\n",
@@ -83,8 +85,9 @@
     "# add the patch to `regroup.py`\n",
     "\n",
     "path_to_local_gfts = \"gfts\"\n",
-    "sys.path.append(Path().home() / path_to_local_gfts / \"scripts\")\n",
-    "from regroups import create_groups, list_tags, rotate_group, convert_to_parquet  # noqa: E402"
+    "sys.path.append(str(Path().home() / path_to_local_gfts / \"scripts\"))\n",
+    "from groups import create_groups, rotate_group, convert_to_parquet  # noqa: E402\n",
+    "from simplify import list_tags  # noqa: E402"
    ]
   },
   {

--- a/docs/workflow/regroup_results.ipynb
+++ b/docs/workflow/regroup_results.ipynb
@@ -129,6 +129,43 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case your study involves different areas (e.g., the tags were processed with different bounding boxes), you need to specify how to regroup the data: either the intersection or union.\n",
+    "\n",
+    "Below, we illustrate how to regroup the data on all the area covered by the tags (i.e., union).\n",
+    "\n",
+    "_NB: Note that this feature only currently supports HEALPix data._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from groups import open_dataset, compute_cell_ids  # noqa: E402\n",
+    "\n",
+    "# pick the tags you want to use for determining the area\n",
+    "tag_names = [\"tag_that_went_to_the_west\", \"tag_that_went_to_the_north\"]\n",
+    "tags = [open_dataset(tag_name) for tag_name in tag_names]\n",
+    "cell_ids = compute_cell_ids(tags, method=\"union\")\n",
+    "print(f\"Found a total of {len(cell_ids)} cells.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# and regroup the data as before, this time including the union specification\n",
+    "groups = create_groups(tag_list, method=\"union\", cell_ids=cell_ids)\n",
+    "groups"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/workflow/simplify_individual_results.ipynb
+++ b/docs/workflow/simplify_individual_results.ipynb
@@ -54,6 +54,8 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
+    "PROFILE = \"gfts\"\n",
+    "\n",
     "SOURCE_BUCKET = \"gfts-ifremer\"\n",
     "TARGET_BUCKET = \"destine-gfts-visualisation-data\"\n",
     "\n",
@@ -71,6 +73,7 @@
    "outputs": [],
    "source": [
     "# set the constant values as environment variables\n",
+    "os.environ[\"PROFILE\"] = PROFILE\n",
     "os.environ[\"SOURCE_BUCKET\"] = SOURCE_BUCKET\n",
     "os.environ[\"TARGET_BUCKET\"] = TARGET_BUCKET\n",
     "os.environ[\"TAG_ROOT\"] = TAG_ROOT\n",
@@ -88,7 +91,7 @@
    "source": [
     "# add the patch to `regroup.py`\n",
     "path_to_local_gfts = \"gfts\"\n",
-    "sys.path.append(Path().home() / path_to_local_gfts / \"scripts\")\n",
+    "sys.path.append(str(Path().home() / path_to_local_gfts / \"scripts\"))\n",
     "from simplify import list_tags, process_tag  # noqa: E402"
    ]
   },

--- a/scripts/simplify.py
+++ b/scripts/simplify.py
@@ -25,13 +25,13 @@ UINT16_MAX = 65535
 
 # remote access
 ENDPOINT = "https://s3.gra.perf.cloud.ovh.net/"
-PROFILE = "ovh_gfts"
 REGION = "gra"
 
 # I/O variables
 # .zarr files are expected to be {SOURCE_BUCKET}/{SOURCE_PREFIX}{tag}/{SOURCE_SUFFIX}states.zarr
 # .parquet files are stored to {TARGET_BUCKET}/{TARGET_PREFIX}{tag}/{tag}_healpix.parquet
 
+PROFILE = os.environ.get("PROFILE", "ovh_gfts")
 SOURCE_BUCKET = os.environ.get("SOURCE_BUCKET", "gfts-ifremer")
 TARGET_BUCKET = os.environ.get("TARGET_BUCKET", "destine-gfts-visualisation-data")
 TAG_ROOT = os.environ.get("TAG_ROOT")


### PR DESCRIPTION
Hi,

I found minor issues in the notebooks for computing the visualization data.
I fixed them and also added an option in `groups.create_groups()` for subsetting or extending the `states` datasets, in order to support studies in which the tags cover different areas.

To summarize, this PR:

1. Fixes the imports in the notebook for regrouping the data quarterly.
2. Enables the definition of the AWS profile in the two visualization notebooks (see the first cells).
3. Adds the support for regrouping the `states` data in the tags span over different areas, by either subsetting the data to the common area (i.e., intersection) or extending it to all the area covered by the tags (i.e., union).
4. Adds a function `compute_cell_ids()` (in `groups.py`) that extracts the indices of the areas mentioned above (intersection or union).
5. Adds a brief illustration in the notebook with the union method.