### PR TITLE
feat: use chainguard for base image

### DIFF
--- a/gfts-track-reconstruction/jupyterhub/images/user/Dockerfile
+++ b/gfts-track-reconstruction/jupyterhub/images/user/Dockerfile
@@ -1,22 +1,77 @@
-FROM quay.io/pangeo/pangeo-notebook:302f739
-# Install fusermount3 command and open GL library
+# Use Chainguard's Python dev image as builder (includes shell and apk)
+FROM cgr.dev/chainguard/python:latest-dev AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies needed for runtime and build
 USER root
-RUN apt-get update && apt-get install -y fuse3 libgl1 xvfb
+RUN apk add --no-cache \
+    fuse3 \
+    mesa-gl \
+    xvfb-run \
+    bash \
+    curl \
+    ca-certificates \
+    build-base \
+    nodejs \
+    npm
 
-USER $NB_USER
-# install some extra packages
-# first, install conda packages from conda-requirements.txt
+# Copy requirements files
 COPY conda-requirements.txt /tmp/conda-requirements.txt
-RUN mamba install -y -n notebook --file /tmp/conda-requirements.txt \
- && mamba clean --all -y
-
-# next pip pacakges from requirements.txt
 COPY requirements.txt /tmp/requirements.txt
+
+# Install micromamba (lightweight conda alternative)
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local bin/micromamba
+
+# Create conda environment and install packages including jupyterlab
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+RUN micromamba create -n notebook python=3.11 jupyterlab nodejs -c conda-forge -y && \
+    micromamba install -n notebook --file /tmp/conda-requirements.txt -c conda-forge -y && \
+    micromamba clean --all -y
+
+# Install pip packages
 ARG PIP_CACHE_DIR=/tmp/pip-cache
-RUN --mount=type=cache,target=$PIP_CACHE_DIR pip install --no-cache -r /tmp/requirements.txt
+RUN --mount=type=cache,target=$PIP_CACHE_DIR \
+    /opt/conda/envs/notebook/bin/pip install --no-cache-dir -r /tmp/requirements.txt
 
-# disable "Jupyter news" pop-up
-RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+# Disable JupyterLab announcements (make it optional in case it fails)
+RUN /opt/conda/envs/notebook/bin/jupyter labextension disable "@jupyterlab/apputils-extension:announcements" || \
+    echo "Warning: Could not disable JupyterLab announcements extension"
 
-WORKDIR /home/$NB_USER
+# Final stage - use the dev image (which has shell) but cleaned up
+FROM cgr.dev/chainguard/python:latest-dev
+
+USER root
+
+# Install only runtime dependencies
+RUN apk add --no-cache \
+    fuse3 \
+    mesa-gl \
+    xvfb-run \
+    bash \
+    nodejs
+
+# Copy conda environment from builder
+COPY --from=builder /opt/conda /opt/conda
+
+# Set up non-root user
+ENV NB_USER=nonroot
+ENV HOME=/home/nonroot
+ENV PATH=/opt/conda/envs/notebook/bin:$PATH
+
+# Create home directory with proper permissions
+RUN mkdir -p /home/nonroot /etc/jupyter && \
+    chown -R nonroot:nonroot /home/nonroot /opt/conda /etc/jupyter
+
+# Copy Jupyter configuration
 COPY jupyter_server_config.py /etc/jupyter/jupyter_server_config.py
+RUN chown nonroot:nonroot /etc/jupyter/jupyter_server_config.py
+
+# Switch to non-root user
+USER nonroot
+WORKDIR /home/nonroot
+
+# Set conda environment activation
+ENV CONDA_DEFAULT_ENV=notebook
+ENV CONDA_PREFIX=/opt/conda/envs/notebook


### PR DESCRIPTION
This pull request significantly refactors the `gfts-track-reconstruction/jupyterhub/images/user/Dockerfile` to modernize the build process, improve security, and optimize the resulting image. The changes include switching to a more secure and minimal base image, using micromamba for environment management, and separating build and runtime stages for a cleaner final image.

**Base image and build process modernization:**
- Switched the base image from `quay.io/pangeo/pangeo-notebook` to Chainguard's minimal and secure Python image (`cgr.dev/chainguard/python:latest-dev`), and adopted a multi-stage build for better separation of build and runtime environments.
- Replaced mamba with micromamba for faster and lighter conda environment creation and management.

**Dependency installation and environment setup:**
- Updated system dependency installation to use Alpine's `apk` instead of Debian's `apt-get`, and streamlined the list of installed packages for both build and runtime stages.
- Ensured all Python, conda, and pip dependencies are installed in the correct environment, and cleaned up caches to reduce image size.

**User and permissions improvements:**
- Added explicit creation and permission setting for a non-root user (`nonroot`), improved home directory setup, and switched